### PR TITLE
#199: Use latest version of innova-controls

### DIFF
--- a/custom_components/innova/climate.py
+++ b/custom_components/innova/climate.py
@@ -178,7 +178,6 @@ class InnovaEntity(CoordinatorEntity[InnovaCoordinator], ClimateEntity):
     def hvac_modes(self):
         """Return available HVAC modes."""
         modes = [HVACMode.OFF]
-        mode: Mode
         for mode in self.coordinator.innova.supported_modes:
             if mode.is_cooling:
                 modes.append(HVACMode.COOL)
@@ -206,10 +205,7 @@ class InnovaEntity(CoordinatorEntity[InnovaCoordinator], ClimateEntity):
 
     @property
     def fan_modes(self) -> list[str] | None:
-        modes = []
-        for fan in self.coordinator.innova.supported_fan_speeds:
-            modes.append(FAN_MAPPINGS[fan])
-        return modes
+        return [FAN_MAPPINGS[fan] for fan in self.coordinator.innova.supported_fan_speeds]
 
     @property
     def fan_mode(self) -> str | None:

--- a/custom_components/innova/manifest.json
+++ b/custom_components/innova/manifest.json
@@ -12,7 +12,7 @@
     "innova"
   ],
   "requirements": [
-    "innova-controls==2.2.1"
+    "innova-controls==2.2.2"
   ],
-  "version": "1.4.5"
+  "version": "1.4.6"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Innova Heat and A/C",
-    "homeassistant": "2024.1.0",
+    "homeassistant": "2024.5.0",
     "country": "CA"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-homeassistant==2024.5.4
-innova-controls==2.2.1
+homeassistant==2024.5.5
+innova-controls==2.2.2


### PR DESCRIPTION
This will let the integration handle fan speed '4'.

Fan Speed 4 is a Boost mode, but it is not supported by the API. Only the remote and the LCD screen can set this speed.
Therefore, I chose to default to report HIGH as the speed since this value cannot be passed to set_fan_speed.